### PR TITLE
Pin upstream revs; Update headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This is a Zig package which provides various X11 headers needed to develop and c
 * xrender
 * xinerama
 * xi
+* xscrnsaver
 * xext
 * xorgproto
 * GLX

--- a/X11/XlibConf.h
+++ b/X11/XlibConf.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2005 Keith Packard
+ *
+ * Permission to use, copy, modify, distribute, and sell this software and its
+ * documentation for any purpose is hereby granted without fee, provided that
+ * the above copyright notice appear in all copies and that both that
+ * copyright notice and this permission notice appear in supporting
+ * documentation, and that the name of Keith Packard not be used in
+ * advertising or publicity pertaining to distribution of the software without
+ * specific, written prior permission.  Keith Packard makes no
+ * representations about the suitability of this software for any purpose.  It
+ * is provided "as is" without express or implied warranty.
+ *
+ * KEITH PACKARD DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+ * INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO
+ * EVENT SHALL KEITH PACKARD BE LIABLE FOR ANY SPECIAL, INDIRECT OR
+ * CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+ * DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+ * TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef _XLIBCONF_H_
+#define _XLIBCONF_H_
+/*
+ * This header file exports defines necessary to correctly
+ * use Xlibint.h both inside Xlib and by external libraries
+ * such as extensions.
+ */
+
+/* Threading support? */
+#define XTHREADS 1
+
+/* Use multi-threaded libc functions? */
+#define XUSE_MTSAFE_API 1
+
+#endif /* _XLIBCONF_H_ */

--- a/X11/Xutil.h
+++ b/X11/Xutil.h
@@ -404,11 +404,11 @@ extern int XDestroyRegion(
     Region		/* r */
 );
 
-extern int XEmptyRegion(
+extern Bool XEmptyRegion(
     Region		/* r */
 );
 
-extern int XEqualRegion(
+extern Bool XEqualRegion(
     Region		/* r1 */,
     Region		/* r2 */
 );

--- a/X11/extensions/scrnsaver.h
+++ b/X11/extensions/scrnsaver.h
@@ -1,0 +1,134 @@
+/*
+ *
+Copyright (c) 1992  X Consortium
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+X CONSORTIUM BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Except as contained in this notice, the name of the X Consortium shall not be
+used in advertising or otherwise to promote the sale, use or other dealings
+in this Software without prior written authorization from the X Consortium.
+ *
+ * Author:  Keith Packard, MIT X Consortium
+ */
+
+#ifndef _SCRNSAVER_H_
+#define _SCRNSAVER_H_
+
+#include <X11/Xfuncproto.h>
+#include <X11/Xlib.h>
+#include <X11/extensions/saver.h>
+
+typedef struct {
+    int	type;		    /* of event */
+    unsigned long serial;   /* # of last request processed by server */
+    Bool send_event;	    /* true if this came from a SendEvent request */
+    Display *display;	    /* Display the event was read from */
+    Window window;	    /* screen saver window */
+    Window root;	    /* root window of event screen */
+    int state;		    /* ScreenSaverOff, ScreenSaverOn, ScreenSaverCycle*/
+    int kind;		    /* ScreenSaverBlanked, ...Internal, ...External */
+    Bool forced;	    /* extents of new region */
+    Time time;		    /* event timestamp */
+} XScreenSaverNotifyEvent;
+
+typedef struct {
+    Window  window;	    /* screen saver window - may not exist */
+    int	    state;	    /* ScreenSaverOff, ScreenSaverOn, ScreenSaverDisabled*/
+    int	    kind;	    /* ScreenSaverBlanked, ...Internal, ...External */
+    unsigned long    til_or_since;   /* time til or since screen saver */
+    unsigned long    idle;	    /* total time since last user input */
+    unsigned long   eventMask; /* currently selected events for this client */
+} XScreenSaverInfo;
+
+_XFUNCPROTOBEGIN
+
+extern Bool XScreenSaverQueryExtension (
+    Display*	/* display */,
+    int*	/* event_base */,
+    int*	/* error_base */
+);
+
+extern Status XScreenSaverQueryVersion (
+    Display*	/* display */,
+    int*	/* major_version */,
+    int*	/* minor_version */
+);
+
+extern XScreenSaverInfo *XScreenSaverAllocInfo (
+    void
+);
+
+extern Status XScreenSaverQueryInfo (
+    Display*		/* display */,
+    Drawable		/* drawable */,
+    XScreenSaverInfo*	/* info */
+);
+
+extern void XScreenSaverSelectInput (
+    Display*	/* display */,
+    Drawable	/* drawable */,
+    unsigned long   /* eventMask */
+);
+
+extern void XScreenSaverSetAttributes (
+    Display*		    /* display */,
+    Drawable		    /* drawable */,
+    int			    /* x */,
+    int			    /* y */,
+    unsigned int	    /* width */,
+    unsigned int	    /* height */,
+    unsigned int	    /* border_width */,
+    int			    /* depth */,
+    unsigned int	    /* class */,
+    Visual *		    /* visual */,
+    unsigned long	    /* valuemask */,
+    XSetWindowAttributes *  /* attributes */
+);
+
+extern void XScreenSaverUnsetAttributes (
+    Display*	/* display */,
+    Drawable	/* drawable */
+);
+
+extern Status XScreenSaverRegister (
+    Display*	/* display */,
+    int		/* screen */,
+    XID		/* xid */,
+    Atom	/* type */
+);
+
+extern Status XScreenSaverUnregister (
+    Display*	/* display */,
+    int		/* screen */
+);
+
+extern Status XScreenSaverGetRegistered (
+    Display*	/* display */,
+    int		/* screen */,
+    XID*	/* xid */,
+    Atom*	/* type */
+);
+
+extern void XScreenSaverSuspend (
+    Display*	/* display */,
+    Bool	/* suspend */
+);
+
+_XFUNCPROTOEND
+
+#endif /* _SCRNSAVER_H_ */

--- a/X11/keysymdef.h
+++ b/X11/keysymdef.h
@@ -81,8 +81,15 @@ SOFTWARE.
  * existing legacy keysym values in the range 0x0100 to 0x20ff.
  *
  * Where several mnemonic names are defined for the same keysym in this
- * file, all but the first one listed should be considered deprecated.
+ * file, all but the first one listed should be considered deprecated,
+ * unless the comment explicitly states the alias, e.g.:
+ * 
+ *     #define XK_dead_tilde            0xfe53
+ *     #define XK_dead_perispomeni      0xfe53 // alias for dead_tilde
  *
+ * Additionally, a keysym can be explicitly deprecated by starting the
+ * comment with "deprecated".
+ * 
  * Mnemonic names for keysyms are defined in this file with lines
  * that match one of these Perl regular expressions:
  *
@@ -196,7 +203,7 @@ SOFTWARE.
 #define XK_Help                          0xff6a  /* Help */
 #define XK_Break                         0xff6b
 #define XK_Mode_switch                   0xff7e  /* Character set switch */
-#define XK_script_switch                 0xff7e  /* Alias for mode_switch */
+#define XK_script_switch                 0xff7e  /* Alias for Mode_switch */
 #define XK_Num_Lock                      0xff7f
 
 /* Keypad functions, keypad numbers cleverly chosen to map to ASCII */
@@ -344,7 +351,7 @@ SOFTWARE.
 #define XK_ISO_Level5_Shift              0xfe11
 #define XK_ISO_Level5_Latch              0xfe12
 #define XK_ISO_Level5_Lock               0xfe13
-#define XK_ISO_Group_Shift               0xff7e  /* Alias for mode_switch */
+#define XK_ISO_Group_Shift               0xff7e  /* Alias for Mode_switch */
 #define XK_ISO_Group_Latch               0xfe06
 #define XK_ISO_Group_Lock                0xfe07
 #define XK_ISO_Next_Group                0xfe08
@@ -431,6 +438,7 @@ SOFTWARE.
 #define XK_dead_capital_schwa            0xfe8b  /* deprecated, remove in 2025 */
 
 #define XK_dead_greek                    0xfe8c
+#define XK_dead_hamza                    0xfe8d
 
 #define XK_First_Virtual_Screen          0xfed0
 #define XK_Prev_Virtual_Screen           0xfed1
@@ -998,7 +1006,7 @@ SOFTWARE.
 #define XK_kana_N                        0x04dd  /* U+30F3 KATAKANA LETTER N */
 #define XK_voicedsound                   0x04de  /* U+309B KATAKANA-HIRAGANA VOICED SOUND MARK */
 #define XK_semivoicedsound               0x04df  /* U+309C KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK */
-#define XK_kana_switch                   0xff7e  /* Alias for mode_switch */
+#define XK_kana_switch                   0xff7e  /* Alias for Mode_switch */
 #endif /* XK_KATAKANA */
 
 /*
@@ -1097,7 +1105,7 @@ SOFTWARE.
 #define XK_Arabic_farsi_yeh           0x10006cc  /* U+06CC ARABIC LETTER FARSI YEH */
 #define XK_Arabic_yeh_baree           0x10006d2  /* U+06D2 ARABIC LETTER YEH BARREE */
 #define XK_Arabic_heh_goal            0x10006c1  /* U+06C1 ARABIC LETTER HEH GOAL */
-#define XK_Arabic_switch                 0xff7e  /* Alias for mode_switch */
+#define XK_Arabic_switch                 0xff7e  /* Alias for Mode_switch */
 #endif /* XK_ARABIC */
 
 /*
@@ -1260,7 +1268,7 @@ SOFTWARE.
 #define XK_Greek_ETAaccent               0x07a3  /* U+0389 GREEK CAPITAL LETTER ETA WITH TONOS */
 #define XK_Greek_IOTAaccent              0x07a4  /* U+038A GREEK CAPITAL LETTER IOTA WITH TONOS */
 #define XK_Greek_IOTAdieresis            0x07a5  /* U+03AA GREEK CAPITAL LETTER IOTA WITH DIALYTIKA */
-#define XK_Greek_IOTAdiaeresis           0x07a5  /* old typo */
+#define XK_Greek_IOTAdiaeresis           0x07a5  /* deprecated (old typo) */
 #define XK_Greek_OMICRONaccent           0x07a7  /* U+038C GREEK CAPITAL LETTER OMICRON WITH TONOS */
 #define XK_Greek_UPSILONaccent           0x07a8  /* U+038E GREEK CAPITAL LETTER UPSILON WITH TONOS */
 #define XK_Greek_UPSILONdieresis         0x07a9  /* U+03AB GREEK CAPITAL LETTER UPSILON WITH DIALYTIKA */
@@ -1329,7 +1337,7 @@ SOFTWARE.
 #define XK_Greek_chi                     0x07f7  /* U+03C7 GREEK SMALL LETTER CHI */
 #define XK_Greek_psi                     0x07f8  /* U+03C8 GREEK SMALL LETTER PSI */
 #define XK_Greek_omega                   0x07f9  /* U+03C9 GREEK SMALL LETTER OMEGA */
-#define XK_Greek_switch                  0xff7e  /* Alias for mode_switch */
+#define XK_Greek_switch                  0xff7e  /* Alias for Mode_switch */
 #endif /* XK_GREEK */
 
 /*
@@ -1589,7 +1597,7 @@ SOFTWARE.
 #define XK_hebrew_shin                   0x0cf9  /* U+05E9 HEBREW LETTER SHIN */
 #define XK_hebrew_taw                    0x0cfa  /* U+05EA HEBREW LETTER TAV */
 #define XK_hebrew_taf                    0x0cfa  /* deprecated */
-#define XK_Hebrew_switch                 0xff7e  /* Alias for mode_switch */
+#define XK_Hebrew_switch                 0xff7e  /* Alias for Mode_switch */
 #endif /* XK_HEBREW */
 
 /*
@@ -1656,7 +1664,7 @@ SOFTWARE.
 #define XK_Thai_sarau                    0x0dd8  /* U+0E38 THAI CHARACTER SARA U */
 #define XK_Thai_sarauu                   0x0dd9  /* U+0E39 THAI CHARACTER SARA UU */
 #define XK_Thai_phinthu                  0x0dda  /* U+0E3A THAI CHARACTER PHINTHU */
-#define XK_Thai_maihanakat_maitho        0x0dde
+#define XK_Thai_maihanakat_maitho        0x0dde  /* (U+0E3E Unassigned code point) */
 #define XK_Thai_baht                     0x0ddf  /* U+0E3F THAI CURRENCY SYMBOL BAHT */
 #define XK_Thai_sarae                    0x0de0  /* U+0E40 THAI CHARACTER SARA E */
 #define XK_Thai_saraae                   0x0de1  /* U+0E41 THAI CHARACTER SARA AE */
@@ -1706,7 +1714,7 @@ SOFTWARE.
 #define XK_Hangul_MultipleCandidate      0xff3d  /* Multiple candidate */
 #define XK_Hangul_PreviousCandidate      0xff3e  /* Previous candidate */
 #define XK_Hangul_Special                0xff3f  /* Special symbols */
-#define XK_Hangul_switch                 0xff7e  /* Alias for mode_switch */
+#define XK_Hangul_switch                 0xff7e  /* Alias for Mode_switch */
 
 /* Hangul Consonant Characters */
 #define XK_Hangul_Kiyeog                 0x0ea1  /* U+3131 HANGUL LETTER KIYEOK */

--- a/build.zig
+++ b/build.zig
@@ -6,12 +6,10 @@ pub fn build(b: *std.Build) void {
 
     const lib = b.addStaticLibrary(.{
         .name = "x11-headers",
-        .root_source_file = .{ .path = "stub.c" },
+        .root_source_file = b.addWriteFiles().add("empty.c", ""),
         .target = target,
         .optimize = optimize,
     });
-
-    lib.linkLibC();
 
     // contains only GLX headers!
     lib.installHeadersDirectory("GL", "GL");

--- a/stub.c
+++ b/stub.c
@@ -1,2 +1,0 @@
-// This file exists for the Zig build sytem to work.
-// In order to "build" this library, there need to be some objects to link.

--- a/xcb/composite.h
+++ b/xcb/composite.h
@@ -254,10 +254,10 @@ xcb_composite_query_version_reply (xcb_connection_t                      *c,
                                    xcb_generic_error_t                  **e);
 
 /**
- * @brief Redirect the heirarchy starting at “window” to off-screen storage.
+ * @brief Redirect the hierarchy starting at "window" to off-screen storage.
  *
  * @param c The connection
- * @param window The root of the heirarchy to redirect to off-screen storage.
+ * @param window The root of the hierarchy to redirect to off-screen storage.
  * @param update A bitmask of #xcb_composite_redirect_t values.
  * @param update Whether contents are automatically mirrored to the parent window.  If one client
  * 	already specifies an update type of Manual, any attempt by another to specify a
@@ -281,10 +281,10 @@ xcb_composite_redirect_window_checked (xcb_connection_t *c,
                                        uint8_t           update);
 
 /**
- * @brief Redirect the heirarchy starting at “window” to off-screen storage.
+ * @brief Redirect the hierarchy starting at "window" to off-screen storage.
  *
  * @param c The connection
- * @param window The root of the heirarchy to redirect to off-screen storage.
+ * @param window The root of the hierarchy to redirect to off-screen storage.
  * @param update A bitmask of #xcb_composite_redirect_t values.
  * @param update Whether contents are automatically mirrored to the parent window.  If one client
  * 	already specifies an update type of Manual, any attempt by another to specify a
@@ -308,7 +308,7 @@ xcb_composite_redirect_window (xcb_connection_t *c,
  * @brief Redirect all current and future children of ‘window’
  *
  * @param c The connection
- * @param window The root of the heirarchy to redirect to off-screen storage.
+ * @param window The root of the hierarchy to redirect to off-screen storage.
  * @param update A bitmask of #xcb_composite_redirect_t values.
  * @param update Whether contents are automatically mirrored to the parent window.  If one client
  * 	already specifies an update type of Manual, any attempt by another to specify a
@@ -333,7 +333,7 @@ xcb_composite_redirect_subwindows_checked (xcb_connection_t *c,
  * @brief Redirect all current and future children of ‘window’
  *
  * @param c The connection
- * @param window The root of the heirarchy to redirect to off-screen storage.
+ * @param window The root of the hierarchy to redirect to off-screen storage.
  * @param update A bitmask of #xcb_composite_redirect_t values.
  * @param update Whether contents are automatically mirrored to the parent window.  If one client
  * 	already specifies an update type of Manual, any attempt by another to specify a

--- a/xcb/dpms.h
+++ b/xcb/dpms.h
@@ -13,13 +13,14 @@
 #define __DPMS_H
 
 #include "xcb.h"
+#include "xproto.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define XCB_DPMS_MAJOR_VERSION 0
-#define XCB_DPMS_MINOR_VERSION 0
+#define XCB_DPMS_MAJOR_VERSION 1
+#define XCB_DPMS_MINOR_VERSION 2
 
 extern xcb_extension_t xcb_dpms_id;
 
@@ -210,6 +211,42 @@ typedef struct xcb_dpms_info_reply_t {
     uint8_t  state;
     uint8_t  pad1[21];
 } xcb_dpms_info_reply_t;
+
+typedef enum xcb_dpms_event_mask_t {
+    XCB_DPMS_EVENT_MASK_INFO_NOTIFY = 1
+} xcb_dpms_event_mask_t;
+
+/** Opcode for xcb_dpms_select_input. */
+#define XCB_DPMS_SELECT_INPUT 8
+
+/**
+ * @brief xcb_dpms_select_input_request_t
+ **/
+typedef struct xcb_dpms_select_input_request_t {
+    uint8_t  major_opcode;
+    uint8_t  minor_opcode;
+    uint16_t length;
+    uint32_t event_mask;
+} xcb_dpms_select_input_request_t;
+
+/** Opcode for xcb_dpms_info_notify. */
+#define XCB_DPMS_INFO_NOTIFY 0
+
+/**
+ * @brief xcb_dpms_info_notify_event_t
+ **/
+typedef struct xcb_dpms_info_notify_event_t {
+    uint8_t         response_type;
+    uint8_t         extension;
+    uint16_t        sequence;
+    uint32_t        length;
+    uint16_t        event_type;
+    uint8_t         pad0[2];
+    xcb_timestamp_t timestamp;
+    uint16_t        power_level;
+    uint8_t         state;
+    uint8_t         pad1[21];
+} xcb_dpms_info_notify_event_t;
 
 /**
  *
@@ -498,6 +535,33 @@ xcb_dpms_info_reply_t *
 xcb_dpms_info_reply (xcb_connection_t        *c,
                      xcb_dpms_info_cookie_t   cookie  /**< */,
                      xcb_generic_error_t    **e);
+
+/**
+ *
+ * @param c The connection
+ * @return A cookie
+ *
+ * Delivers a request to the X server.
+ *
+ * This form can be used only if the request will not cause
+ * a reply to be generated. Any returned error will be
+ * saved for handling by xcb_request_check().
+ */
+xcb_void_cookie_t
+xcb_dpms_select_input_checked (xcb_connection_t *c,
+                               uint32_t          event_mask);
+
+/**
+ *
+ * @param c The connection
+ * @return A cookie
+ *
+ * Delivers a request to the X server.
+ *
+ */
+xcb_void_cookie_t
+xcb_dpms_select_input (xcb_connection_t *c,
+                       uint32_t          event_mask);
 
 
 #ifdef __cplusplus

--- a/xcb/shm.h
+++ b/xcb/shm.h
@@ -431,10 +431,10 @@ xcb_shm_detach (xcb_connection_t *c,
  * @param dst_y The Y coordinate on the destination drawable to copy to.
  * @param depth The depth to use.
  * @param format The format of the image being drawn.  If it is XYBitmap, depth must be 1, or a
- * “BadMatch” error results.  The foreground pixel in the GC determines the source
+ * "BadMatch" error results.  The foreground pixel in the GC determines the source
  * for the one bits in the image, and the background pixel determines the source
  * for the zero bits.  For XYPixmap and ZPixmap, the depth must match the depth of
- * the drawable, or a “BadMatch” error results.
+ * the drawable, or a "BadMatch" error results.
  * @param send_event True if the server should send an XCB_SHM_COMPLETION event when the blit
  * completes.
  * @param offset The offset that the source image starts at.
@@ -486,10 +486,10 @@ xcb_shm_put_image_checked (xcb_connection_t *c,
  * @param dst_y The Y coordinate on the destination drawable to copy to.
  * @param depth The depth to use.
  * @param format The format of the image being drawn.  If it is XYBitmap, depth must be 1, or a
- * “BadMatch” error results.  The foreground pixel in the GC determines the source
+ * "BadMatch" error results.  The foreground pixel in the GC determines the source
  * for the one bits in the image, and the background pixel determines the source
  * for the zero bits.  For XYPixmap and ZPixmap, the depth must match the depth of
- * the drawable, or a “BadMatch” error results.
+ * the drawable, or a "BadMatch" error results.
  * @param send_event True if the server should send an XCB_SHM_COMPLETION event when the blit
  * completes.
  * @param offset The offset that the source image starts at.

--- a/xkbcommon/xkbcommon.h
+++ b/xkbcommon/xkbcommon.h
@@ -169,28 +169,37 @@ typedef uint32_t xkb_keycode_t;
  *
  * A key, represented by a keycode, may generate different symbols according
  * to keyboard state.  For example, on a QWERTY keyboard, pressing the key
- * labled \<A\> generates the symbol 'a'.  If the Shift key is held, it
- * generates the symbol 'A'.  If a different layout is used, say Greek,
- * it generates the symbol 'α'.  And so on.
+ * labled \<A\> generates the symbol ‘a’.  If the Shift key is held, it
+ * generates the symbol ‘A’.  If a different layout is used, say Greek,
+ * it generates the symbol ‘α’.  And so on.
  *
- * Each such symbol is represented by a keysym.  Note that keysyms are
- * somewhat more general, in that they can also represent some "function",
- * such as "Left" or "Right" for the arrow keys.  For more information,
- * see:
- * https://www.x.org/releases/current/doc/xproto/x11protocol.html#keysym_encoding
+ * Each such symbol is represented by a *keysym* (short for “key symbol”).
+ * Note that keysyms are somewhat more general, in that they can also represent
+ * some “function”, such as “Left” or “Right” for the arrow keys.  For more
+ * information, see: Appendix A [“KEYSYM Encoding”][encoding] of the X Window
+ * System Protocol.
  *
  * Specifically named keysyms can be found in the
  * xkbcommon/xkbcommon-keysyms.h header file.  Their name does not include
- * the XKB_KEY_ prefix.
+ * the `XKB_KEY_` prefix.
  *
- * Besides those, any Unicode/ISO 10646 character in the range U0100 to
- * U10FFFF can be represented by a keysym value in the range 0x01000100 to
- * 0x0110FFFF.  The name of Unicode keysyms is "U<codepoint>", e.g. "UA1B2".
+ * Besides those, any Unicode/ISO&nbsp;10646 character in the range U+0100 to
+ * U+10FFFF can be represented by a keysym value in the range 0x01000100 to
+ * 0x0110FFFF.  The name of Unicode keysyms is `U<codepoint>`, e.g. `UA1B2`.
  *
  * The name of other unnamed keysyms is the hexadecimal representation of
- * their value, e.g. "0xabcd1234".
+ * their value, e.g. `0xabcd1234`.
  *
  * Keysym names are case-sensitive.
+ *
+ * @note **Encoding:** Keysyms are 32-bit integers with the 3 most significant
+ * bits always set to zero.  See: Appendix A [“KEYSYM Encoding”][encoding] of
+ * the X Window System Protocol.
+ *
+ * [encoding]: https://www.x.org/releases/current/doc/xproto/x11protocol.html#keysym_encoding
+ *
+ * @ingroup keysyms
+ * @sa XKB_KEYSYM_MAX
  */
 typedef uint32_t xkb_keysym_t;
 
@@ -304,6 +313,15 @@ typedef uint32_t xkb_led_mask_t;
 #define XKB_KEYCODE_MAX     (0xffffffff - 1)
 
 /**
+ * Maximum keysym value
+ *
+ * @since 1.6.0
+ * @sa xkb_keysym_t
+ * @ingroup keysyms
+ */
+#define XKB_KEYSYM_MAX      0x1fffffff
+
+/**
  * Test whether a value is a valid extended keycode.
  * @sa xkb_keycode_t
  **/
@@ -380,7 +398,7 @@ struct xkb_rule_names {
 
 /**
  * @defgroup keysyms Keysyms
- * Utility functions related to keysyms.
+ * Utility functions related to *keysyms* (short for “key symbols”).
  *
  * @{
  */


### PR DESCRIPTION
Closes https://github.com/hexops/mach/issues/818.

- Pins upstream revs.
- Adds the missing config header `<X11/XlibConf.h>`.
- Adds `<X11/extensions/scrnsaver.h>` from [xscrnsaver](https://gitlab.freedesktop.org/xorg/lib/libxscrnsaver) (required by SDL2/3).

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.